### PR TITLE
refactor!: update assert function to include reason argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,13 @@ const CountVowel = struct {
     vowels: []const u8,
 };
 
-// you _must_ export a single `test` function (in Zig, "test" is a keyword, so use this raw literal syntax)
 export fn @"test"() i32 {
-    // initialize your test to run functions in a target plugin
     const xtp_test = Test.init(std.heap.wasm_allocator);
-    xtp_test.assert("this is a test", true);
-
-    // run the "count_vowels" function in the target plugin and assert the output is as expected
     const output = xtp_test.call("count_vowels", "this is a test") catch unreachable;
     const cv = fromJson(output);
     xtp_test.assertEq("count_vowels returns expected count", cv.count, 4);
 
     // create a group of tests inside a new scope, use defer to close the group at the end of the scope
-    // NOTE: creating a group will reset the target plugin, before the group starts and after it's closed
     {
         const maintain_state_group = xtp_test.newGroup("plugin should maintain state");
         defer maintain_state_group.close();
@@ -43,13 +37,11 @@ export fn @"test"() i32 {
 
     // create a group without a scope, and close it manually at the end of your tests
     const simple_group = xtp_test.newGroup("simple timing tests");
-    // get the number of seconds elapsed in the "count_vowels" function using some input
     const sec = xtp_test.timeSec("count_vowels", "this is a test");
-    xtp_test.assert("it should be fast", sec < 0.5);
+    xtp_test.assertLt("it should be fast", sec, 0.5);
 
-    // get the number of nanoseconds elapsed in the "count_vowels" function using some input
     const ns = xtp_test.timeNs("count_vowels", "this is a test");
-    xtp_test.assert("it should be really fast", ns < 1e5);
+    xtp_test.assertLt("it should be really fast", ns, 1e5);
     simple_group.close();
 
     return 0;
@@ -93,7 +85,7 @@ const CountVowel = struct {
 export fn @"test"() i32 {
     // initialize your test to run functions in a target plugin
     const xtp_test = Test.init(std.heap.wasm_allocator);
-    xtp_test.assert("this is a test", true);
+    xtp_test.assert("this is a test", true, "Expect true == true");
 
     // run the "count_vowels" function in the target plugin and assert the output is as expected
     const output = xtp_test.call("count_vowels", "this is a test") catch unreachable;
@@ -127,9 +119,9 @@ curl https://static.dylibso.com/cli/install.sh | sudo sh
 ### Run the test suite
 
 ```sh
-xtp plugin test ./plugin-*.wasm --with test.wasm --host host.wasm
-#               ^^^^^^^^^^^^^^^        ^^^^^^^^^        ^^^^^^^^^
-#               your plugin(s)         test to run      optional mock host functions
+xtp plugin test ./plugin-*.wasm --with test.wasm --mock-host host.wasm
+#               ^^^^^^^^^^^^^^^        ^^^^^^^^^             ^^^^^^^^^
+#               your plugin(s)         test to run           optional mock host functions
 ```
 
 **Note:** The optional mock host functions must be implemented as Extism

--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,6 @@ pub fn build(b: *std.Build) void {
     });
     basic_test.rdynamic = true;
     basic_test.entry = .disabled; // or, add an empty `pub fn main() void {}` in your code
-    // basic_test.root_module.addImport("extism-pdk", pdk_module);
     basic_test.root_module.addImport("xtp-test", xtp_test_module);
 
     b.installArtifact(basic_test);

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -9,7 +9,11 @@ const CountVowel = struct {
 
 export fn @"test"() i32 {
     const xtp_test = Test.init(std.heap.wasm_allocator);
-    xtp_test.assert("this is a test", true);
+    xtp_test.assertEq("this is a test", true, true);
+    xtp_test.assertGt("gt test", 10, 1);
+    xtp_test.assertGte("gte test", 10.4, 10.4);
+    xtp_test.assertLt("lt test", 'Z', 'a');
+    xtp_test.assertLte("lte test", 0xfeeddada, 0xfeeddada);
     const output = xtp_test.call("count_vowels", "this is a test") catch unreachable;
     const cv = fromJson(output);
     xtp_test.assertEq("count_vowels returns expected count", cv.count, 4);
@@ -31,10 +35,10 @@ export fn @"test"() i32 {
     // create a group without a scope, and close it manually at the end of your tests
     const simple_group = xtp_test.newGroup("simple timing tests");
     const sec = xtp_test.timeSec("count_vowels", "this is a test");
-    xtp_test.assert("it should be fast", sec < 0.5);
+    xtp_test.assertLt("it should be fast", sec, 0.5);
 
     const ns = xtp_test.timeNs("count_vowels", "this is a test");
-    xtp_test.assert("it should be really fast", ns < 1e5);
+    xtp_test.assertLt("it should be really fast", ns, 1e5);
     simple_group.close();
 
     return 0;

--- a/src/harness.zig
+++ b/src/harness.zig
@@ -1,5 +1,5 @@
 pub extern "xtp:test/harness" fn call(u64, u64) u64;
 pub extern "xtp:test/harness" fn time(u64, u64) u64;
-pub extern "xtp:test/harness" fn assert(u64, u64) void;
+pub extern "xtp:test/harness" fn assert(u64, u64, u64) void;
 pub extern "xtp:test/harness" fn reset() void;
 pub extern "xtp:test/harness" fn group(u64) void;

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,7 +64,7 @@ pub const Test = struct {
         self.assert(msg, x != y, reason);
     }
 
-    // Assert that `x` is greater than `y` are not equal, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+    // Assert that `x` is greater than `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
     pub fn assertGt(self: Test, msg: []const u8, x: anytype, y: anytype) void {
         const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} > {}", .{ x, y }) catch FORMAT_FAILED;
         self.assert(msg, x > y, reason);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,8 @@ const Plugin = pdk.Plugin;
 const Memory = pdk.Memory;
 const harness = @import("harness.zig");
 
+const FORMAT_FAILED = "-- test runner failed to format reason --";
+
 pub const Test = struct {
     plugin: Plugin,
 
@@ -16,10 +18,10 @@ pub const Test = struct {
         const func_mem = self.plugin.allocateBytes(func_name);
         const input_mem = self.plugin.allocateBytes(input);
         const output = harness.call(func_mem.offset, input_mem.offset);
-        errdefer func_mem.free();
-        errdefer input_mem.free();
+        defer func_mem.free();
+        defer input_mem.free();
         const output_mem = self.plugin.findMemory(output);
-        errdefer output_mem.free();
+        defer output_mem.free();
         const buf = try self.plugin.allocator.alloc(u8, @intCast(output_mem.length));
         errdefer self.plugin.allocator.free(buf);
         output_mem.load(buf);
@@ -31,8 +33,8 @@ pub const Test = struct {
         const func_mem = self.plugin.allocateBytes(func_name);
         const input_mem = self.plugin.allocateBytes(input);
         const ns = harness.time(func_mem.offset, input_mem.offset);
-        errdefer func_mem.free();
-        errdefer input_mem.free();
+        defer func_mem.free();
+        defer input_mem.free();
         return ns;
     }
 
@@ -42,20 +44,48 @@ pub const Test = struct {
     }
 
     // Assert that the `outcome` is true, naming the assertion with `msg`, which will be used as a label in the CLI runner.
-    pub fn assert(self: Test, msg: []const u8, outcome: bool) void {
+    pub fn assert(self: Test, msg: []const u8, outcome: bool, reason: []const u8) void {
         const msg_mem = self.plugin.allocateBytes(msg);
-        harness.assert(msg_mem.offset, @intFromBool(outcome));
+        const reason_mem = self.plugin.allocateBytes(reason);
+        harness.assert(msg_mem.offset, @intFromBool(outcome), reason_mem.offset);
         msg_mem.free();
+        reason_mem.free();
     }
 
     // Assert that `x` and `y` are equal, naming the assertion with `msg`, which will be used as a label in the CLI runner.
     pub fn assertEq(self: Test, msg: []const u8, x: anytype, y: anytype) void {
-        self.assert(msg, x == y);
+        const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} == {}", .{ x, y }) catch FORMAT_FAILED;
+        self.assert(msg, x == y, reason);
     }
 
     // Assert that `x` and `y` are not equal, naming the assertion with `msg`, which will be used as a label in the CLI runner.
     pub fn assertNe(self: Test, msg: []const u8, x: anytype, y: anytype) void {
-        self.assert(msg, x != y);
+        const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} != {}", .{ x, y }) catch FORMAT_FAILED;
+        self.assert(msg, x != y, reason);
+    }
+
+    // Assert that `x` is greater than `y` are not equal, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+    pub fn assertGt(self: Test, msg: []const u8, x: anytype, y: anytype) void {
+        const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} > {}", .{ x, y }) catch FORMAT_FAILED;
+        self.assert(msg, x > y, reason);
+    }
+
+    // Assert that `x` is greater than or equal to `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+    pub fn assertGte(self: Test, msg: []const u8, x: anytype, y: anytype) void {
+        const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} >= {}", .{ x, y }) catch FORMAT_FAILED;
+        self.assert(msg, x >= y, reason);
+    }
+
+    // Assert that `x` is less than `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+    pub fn assertLt(self: Test, msg: []const u8, x: anytype, y: anytype) void {
+        const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} < {}", .{ x, y }) catch FORMAT_FAILED;
+        self.assert(msg, x < y, reason);
+    }
+
+    // Assert that `x` is less than or equal to `y`, naming the assertion with `msg`, which will be used as a label in the CLI runner.
+    pub fn assertLte(self: Test, msg: []const u8, x: anytype, y: anytype) void {
+        const reason = std.fmt.allocPrint(self.plugin.allocator, "Expected {} <= {}", .{ x, y }) catch FORMAT_FAILED;
+        self.assert(msg, x <= y, reason);
     }
 
     // Create a new test group. NOTE: these cannot be nested and starting a new group will end the last one


### PR DESCRIPTION
Brings `xtp-test-zig` up to date with the XTP CLI test runner. 

Also, includes `assertGt`, `assertGte`, `assertLt`, `assertLte` for convenience - especially with timing tests. 